### PR TITLE
Add databricks-lakehouse stack and CI templates

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,28 @@
+# Status
+
+Last updated: 2026-03-01
+
+## Completed
+
+### TASK-001: Databricks-lakehouse stack config
+- Added `configs/databricks-lakehouse.yaml` with notebooks structure, DLT, Unity Catalog conventions
+- Updated `VALID_STACKS` in `scaffold.py` to include `databricks-lakehouse`
+- Added 5 tests in `TestDatabricksLakehouseStack` (directories, extra files, config loading, core files, template substitution)
+
+### TASK-002: GitHub Actions CI templates
+- Created `templates/.github/workflows/ci-python.yml.tmpl` (ruff lint + pytest)
+- Created `templates/.github/workflows/ci-docs.yml.tmpl` (markdownlint)
+- Added CI template selection logic in `scaffold.py` — maps stack type to CI template
+- Added 4 tests in `TestCITemplateSelection` (python-data, docs-only, no placeholders, databricks)
+
+## Test Summary
+- 28 tests across 7 test classes — all passing
+- scaffold.py: 241 lines (under 300-line limit)
+
+## Supported Stacks
+| Stack | CI Template | Description |
+|---|---|---|
+| python-data | ci-python.yml | Medallion architecture data project |
+| python-web | ci-python.yml | Python web service |
+| docs-only | ci-docs.yml | Documentation-only repo |
+| databricks-lakehouse | ci-python.yml | Databricks lakehouse with DLT |

--- a/backlog/TASK-001.yaml
+++ b/backlog/TASK-001.yaml
@@ -7,7 +7,7 @@ description: |
   structure, and appropriate CLAUDE.md with Databricks conventions.
   Extend scaffold.py to handle the new stack.
 
-status: ready
+status: done
 priority: medium
 agent: code
 review: agent-review
@@ -27,7 +27,7 @@ estimate: m
 
 actual_tokens: null
 actual_duration_minutes: null
-completed: null
+completed: "2026-03-01"
 
 created: 2026-03-01
 updated: 2026-03-01

--- a/backlog/TASK-002.yaml
+++ b/backlog/TASK-002.yaml
@@ -7,7 +7,7 @@ description: |
   conditional on stack type (Python stacks get pytest, docs-only
   gets markdown lint).
 
-status: backlog
+status: done
 priority: low
 agent: code
 review: agent-review
@@ -27,7 +27,7 @@ estimate: m
 
 actual_tokens: null
 actual_duration_minutes: null
-completed: null
+completed: "2026-03-01"
 
 created: 2026-03-01
 updated: 2026-03-01

--- a/configs/databricks-lakehouse.yaml
+++ b/configs/databricks-lakehouse.yaml
@@ -1,0 +1,23 @@
+stack: databricks-lakehouse
+description: "Databricks lakehouse project with medallion architecture and DLT"
+directories:
+  - notebooks/bronze
+  - notebooks/silver
+  - notebooks/gold
+  - notebooks/dlt
+  - src/utils
+  - src/schemas
+  - tests
+  - docs/adr
+  - backlog
+  - .claude/commands
+  - .engineering
+extra_files:
+  - requirements.txt
+  - databricks.yml
+conventions:
+  naming: snake_case
+  sql_prefix: true
+  medallion: true
+  unity_catalog: true
+  dlt: true

--- a/scaffold.py
+++ b/scaffold.py
@@ -144,6 +144,23 @@ def create_project(name: str, stack: str, mode: str, output_dir: Path) -> Path:
         file_path.touch()
         created_files.append(filename)
 
+    # ----- CI template selection based on stack -----
+    ci_template_map = {
+        "docs-only": "ci-docs.yml.tmpl",
+        "python-data": "ci-python.yml.tmpl",
+        "python-web": "ci-python.yml.tmpl",
+        "databricks-lakehouse": "ci-python.yml.tmpl",
+    }
+    ci_template_name = ci_template_map.get(stack)
+    if ci_template_name:
+        ci_template_path = TEMPLATES_DIR / ".github" / "workflows" / ci_template_name
+        ci_content = render_template(ci_template_path, context)
+        if ci_content:
+            ci_file_path = project_dir / ".github" / "workflows" / "ci.yml"
+            ci_file_path.parent.mkdir(parents=True, exist_ok=True)
+            ci_file_path.write_text(ci_content)
+            created_files.append(".github/workflows/ci.yml")
+
     # ----- Print summary -----
     print(f"\nProject '{name}' created at: {project_dir}")
     print(f"Stack: {stack}")

--- a/scaffold.py
+++ b/scaffold.py
@@ -33,7 +33,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 TEMPLATES_DIR = SCRIPT_DIR / "templates"
 CONFIGS_DIR = SCRIPT_DIR / "configs"
 
-VALID_STACKS = ["python-data", "python-web", "docs-only"]
+VALID_STACKS = ["python-data", "python-web", "docs-only", "databricks-lakehouse"]
 VALID_MODES = ["solo", "team"]
 
 

--- a/templates/.github/workflows/ci-docs.yml.tmpl
+++ b/templates/.github/workflows/ci-docs.yml.tmpl
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-markdown:
+    name: Lint Markdown
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v19
+        with:
+          globs: "**/*.md"

--- a/templates/.github/workflows/ci-python.yml.tmpl
+++ b/templates/.github/workflows/ci-python.yml.tmpl
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ruff
+      - run: ruff check .
+      - run: ruff format --check .
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: |
+          pip install -r requirements.txt 2>/dev/null || true
+          pip install pytest
+      - run: python -m pytest tests/ -v --tb=short

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -237,3 +237,39 @@ class TestDatabricksLakehouseStack:
         assert "my-db-project" in content
         assert "databricks-lakehouse" in content
         assert "{{" not in content
+
+
+# ---------------------------------------------------------------------------
+# CI template selection tests
+# ---------------------------------------------------------------------------
+
+class TestCITemplateSelection:
+    """Tests for CI template generation based on stack type."""
+
+    def test_python_data_gets_pytest_ci(self, tmp_output_dir):
+        project_dir = create_project("test-ci", "python-data", "solo", tmp_output_dir)
+        ci_file = project_dir / ".github" / "workflows" / "ci.yml"
+        assert ci_file.exists()
+        content = ci_file.read_text()
+        assert "pytest" in content
+        assert "ruff" in content
+
+    def test_docs_only_gets_markdownlint_ci(self, tmp_output_dir):
+        project_dir = create_project("test-ci-docs", "docs-only", "solo", tmp_output_dir)
+        ci_file = project_dir / ".github" / "workflows" / "ci.yml"
+        assert ci_file.exists()
+        content = ci_file.read_text()
+        assert "markdownlint" in content.lower() or "markdown" in content.lower()
+
+    def test_ci_template_no_unresolved_placeholders(self, tmp_output_dir):
+        project_dir = create_project("test-ci-clean", "python-web", "team", tmp_output_dir)
+        ci_file = project_dir / ".github" / "workflows" / "ci.yml"
+        content = ci_file.read_text()
+        assert "{{" not in content
+
+    def test_databricks_gets_python_ci(self, tmp_output_dir):
+        project_dir = create_project("test-ci-db", "databricks-lakehouse", "solo", tmp_output_dir)
+        ci_file = project_dir / ".github" / "workflows" / "ci.yml"
+        assert ci_file.exists()
+        content = ci_file.read_text()
+        assert "pytest" in content

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -196,3 +196,44 @@ class TestLoadConfig:
         config = load_config("docs-only")
         assert config["stack"] == "docs-only"
         assert config["extra_files"] == []
+
+
+# ---------------------------------------------------------------------------
+# Databricks-lakehouse stack tests
+# ---------------------------------------------------------------------------
+
+class TestDatabricksLakehouseStack:
+    """Tests for the databricks-lakehouse stack."""
+
+    def test_databricks_directories(self, tmp_output_dir):
+        project_dir = create_project("test-db", "databricks-lakehouse", "solo", tmp_output_dir)
+        assert (project_dir / "notebooks" / "bronze").is_dir()
+        assert (project_dir / "notebooks" / "silver").is_dir()
+        assert (project_dir / "notebooks" / "gold").is_dir()
+        assert (project_dir / "notebooks" / "dlt").is_dir()
+        assert (project_dir / "src" / "utils").is_dir()
+        assert (project_dir / "src" / "schemas").is_dir()
+
+    def test_databricks_extra_files(self, tmp_output_dir):
+        project_dir = create_project("test-db", "databricks-lakehouse", "solo", tmp_output_dir)
+        assert (project_dir / "requirements.txt").exists()
+        assert (project_dir / "databricks.yml").exists()
+
+    def test_databricks_config_loading(self):
+        config = load_config("databricks-lakehouse")
+        assert config["stack"] == "databricks-lakehouse"
+        assert config["conventions"]["unity_catalog"] is True
+        assert config["conventions"]["dlt"] is True
+
+    def test_databricks_core_files(self, tmp_output_dir):
+        project_dir = create_project("test-db2", "databricks-lakehouse", "solo", tmp_output_dir)
+        assert (project_dir / "CLAUDE.md").exists()
+        assert (project_dir / "backlog" / "TASK-001.yaml").exists()
+        assert (project_dir / ".engineering" / "ruff.toml").exists()
+
+    def test_databricks_template_substitution(self, tmp_output_dir):
+        project_dir = create_project("my-db-project", "databricks-lakehouse", "solo", tmp_output_dir)
+        content = (project_dir / "CLAUDE.md").read_text()
+        assert "my-db-project" in content
+        assert "databricks-lakehouse" in content
+        assert "{{" not in content


### PR DESCRIPTION
## Summary
- **TASK-001**: New `databricks-lakehouse` stack config with notebooks structure (bronze/silver/gold/dlt), Unity Catalog and DLT conventions, and `databricks.yml` extra file
- **TASK-002**: GitHub Actions CI templates — Python stacks get ruff lint + pytest, docs-only gets markdownlint. CI template is auto-selected based on stack type during scaffolding
- 28 tests across 7 test classes, all passing. scaffold.py at 241 lines (under 300-line limit)

## Test plan
- [x] 28 pytest tests green (5 new for databricks stack, 4 new for CI templates)
- [x] End-to-end validation: `scaffold.py --stack databricks-lakehouse` generates correct structure
- [x] Verified `notebooks/bronze` directory and `.github/workflows/ci.yml` exist in output
- [x] scaffold.py stays under 300 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)